### PR TITLE
Fixed livereload 'ERR CONNECTION REFUSED' issue

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -217,7 +217,7 @@ gulp.task('watch', ['statics', 'default'], function() {
   isWatching = true;
 
   // Initiate livereload server:
-  g.livereload();
+  g.livereload.listen();
 
   gulp.watch('./src/app/**/*.js', ['jshint']).on('change', function(evt) {
     if (evt.type !== 'changed') {


### PR DESCRIPTION
Livereload did not work for me as it is in the current version. adding listen() resolves it (based on https://scotch.io/tutorials/a-quick-guide-to-using-livereload-with-gulp)
